### PR TITLE
Be explicit about global window for client context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,59 +1,33 @@
-var fs = require("fs");
-var isHTML = require("is-html");
-var path = require("path");
-var once = require("once");
+var fs = require('fs');
+var isHTML = require('is-html');
+var path = require('path');
 
-module.exports = function(request, options = {}){
-	var hasPageHTML = !!options.html;
-	options.root = options.root || process.cwd();
-	if(options.html && !isHTML(options.html)) {
-		// It's a path
-		var pth = options.html;
-		if(!path.isAbsolute(pth)) {
-			pth = path.join(options.root, pth);
-		}
-		options.html = fs.readFileSync(pth, "utf8");
-	}
-	options.html = options.html || "<html></html>";
+module.exports = function(request, options = {}) {
+  var hasPageHTML = !!options.html;
+  options.root = options.root || process.cwd();
+  if (options.html && !isHTML(options.html)) {
+    // It's a path
+    var pth = options.html;
+    if (!path.isAbsolute(pth)) {
+      pth = path.join(options.root, pth);
+    }
+    options.html = fs.readFileSync(pth, 'utf8');
+  }
+  options.html = options.html || '<html></html>';
 
-	return function(data){
-		var windowProps;
+  return function(data) {
+    var plugins = [require('./dom')(request, options.html)];
 
-		var getWindowProps = once(function(){
-			var window = data.window;
-			windowProps = Object.assign({}, {
-				window: window,
-				document: window.document,
-				location: window.location,
-				navigator: window.navigator
-			});
-			data.document = window.document;
-		});
+    // Only add the run-html plugin if page html is provided
+    if (hasPageHTML) {
+      plugins.push(require('./run-html')(request, options));
+    }
 
-		var plugins = [
-			require("./dom")(request, options.html)
-		];
-
-		// Only add the run-html plugin if page html is provided
-		if(hasPageHTML) {
-			plugins.push(
-				require("./run-html")(request, options)
-			);
-		}
-
-		return {
-			plugins: plugins,
-			created: function(){
-				getWindowProps();
-			},
-			beforeTask: function(){
-				getWindowProps();
-				Object.assign(global, windowProps);
-			},
-			ended: function(){
-				data.html = data.document.documentElement.outerHTML;
-			}
-		};
-
-	};
+    return {
+      plugins: plugins,
+      ended: function() {
+        data.html = data.document.documentElement.outerHTML;
+      }
+    };
+  };
 };

--- a/lib/run-html.js
+++ b/lib/run-html.js
@@ -8,11 +8,28 @@ module.exports = function(request, options){
 			var doc = data.document;
 			var scripts = Array.from(doc.getElementsByTagName("script"));
 
+			// Put global methods on the window object
+			Object.assign(data.window, {
+				fetch,
+				WebSocket,
+				TextDecoder,
+				ReadableStream,
+				addEventListener,
+				XMLHttpRequest,
+				setTimeout,
+				clearImmediate,
+				clearInterval,
+				clearTimeout,
+				setImmediate,
+				setInterval,
+				process,
+			});
+
 			scripts.forEach(function(script){
-				var code, fn;
+				var code, filename;
 				if(script.src) {
-					fn = path.join(options.root, request.url, script.src);
-					code = fs.readFileSync(fn, "utf8");
+					filename = path.join(options.root, request.url, script.src);
+					code = fs.readFileSync(filename, "utf8");
 				} else {
 					code = script.textContent;
 				}
@@ -21,9 +38,9 @@ module.exports = function(request, options){
 				var runScript = !script.dataset.streamurl;
 
 				if(runScript) {
-					vm.runInThisContext(`(function(){
-						${code}
-					})()`, fn);
+					vm.runInNewContext(code, data.window, {
+						filename
+					});
 				}
 			});
 		}


### PR DESCRIPTION
This is more of a **Discussion** PR than a merge PR, so feel free to close or whatever.

I was thinking, wouldn't it be better, if rather than using the node `global` as our clients run `widow`/`global`, we explicitly passed the global to `vm` when running the client code.

It feels a little simpler to understand to me this way, and might prevent accidental API use.

What do you think though?