### PR TITLE
Enable turning off script execution

### DIFF
--- a/lib/run-html.js
+++ b/lib/run-html.js
@@ -31,8 +31,11 @@ module.exports = function(request, options){
 		return {
 			created: function(){
 				var run = this.run;
+				// If executeScripts is turned off, use a noop as the run function.
+				var runFn = options.executeScripts === false ? Function.prototype :
+					executeScripts;
 				this.run = function(){
-					return run.call(this, executeScripts);
+					return run.call(this, runFn);
 				};
 			}
 		};

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -114,4 +114,38 @@ describe("SSR Zones - HTML", function(){
 			});
 		});
 	});
+
+	describe("executeScripts: false doesn't run the scripts", function(){
+		var pageHTML = fs.readFileSync(__dirname + "/html/page.html", "utf8");
+
+		before(function(){
+			return spinUpServer(() => {
+				var request = new Request();
+				var response = this.response = new Response();
+
+				var zone = this.zone = new Zone({
+					plugins: [
+						// Overrides XHR, fetch
+						requests(request),
+
+						// Sets up a DOM
+						dom(request, {
+							root: __dirname + "/html",
+							html: "page.html",
+							executeScripts: false
+						})
+					]
+				});
+
+				return zone.run();
+			});
+		});
+
+		it("Includes the right HTML", function(){
+			var dom = helpers.dom(this.zone.data.html);
+			var ul = helpers.find(dom, node => node.nodeName === "UL");
+
+			assert.ok(!ul, "the ul was not added because no scripts ran");
+		});
+	});
 });


### PR DESCRIPTION
This adds an option `executeScripts: false` that prevents scripts from
being executed. Closes #9